### PR TITLE
Ignore GeneratedField in trigger function

### DIFF
--- a/pghistory/tests/test_models.py
+++ b/pghistory/tests/test_models.py
@@ -928,7 +928,9 @@ def test_generated_field():
 
     class GeneratedFieldModel(models.Model):
         value = models.TextField()
-        generated_field = models.GeneratedField(expression=F("value"), output_field=models.TextField(), db_persist=True)
+        generated_field = models.GeneratedField(
+            expression=F("value"), output_field=models.TextField(), db_persist=True
+        )
 
     tracked = pghistory.create_event_model(GeneratedFieldModel)
 

--- a/pghistory/tests/test_models.py
+++ b/pghistory/tests/test_models.py
@@ -4,9 +4,13 @@ import ddf
 import django
 import pytest
 from django.core.management import call_command
+from django.db import models
+from django.db.models import F
 
 import pghistory.runtime
 import pghistory.tests.models as test_models
+from pghistory import Update
+from pghistory.trigger import Event
 
 
 @pytest.mark.django_db
@@ -913,3 +917,21 @@ def test_custom_foreign_key_to_m2m_through():
     will perform model checks using Django's check framework
     """
     call_command("check")
+
+
+@pytest.mark.skipif(django.VERSION[0] < 5, reason="GeneratedField not supported on Django<5")
+@pytest.mark.django_db
+def test_generated_field():
+    """
+    Ensure that GeneratedFields are not included in the trigger's SQL
+    """
+
+    class GeneratedFieldModel(models.Model):
+        value = models.TextField()
+        generated_field = models.GeneratedField(expression=F("value"), output_field=models.TextField(), db_persist=True)
+
+    tracked = pghistory.create_event_model(GeneratedFieldModel)
+
+    event = Event(event_model=tracked, label="GeneratedFieldModel", operation=Update)
+    sql = event.get_func(tracked)
+    assert "generated_field" not in sql

--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -73,6 +73,7 @@ class Event(pgtrigger.Trigger):
             f.column: f'{self.row}."{f.column}"'
             for f in self.event_model._meta.fields
             if not isinstance(f, models.AutoField)
+            and not isinstance(f, models.GeneratedField)
             and f.name in tracked_model_fields
             and f.concrete
         }

--- a/pghistory/trigger.py
+++ b/pghistory/trigger.py
@@ -1,5 +1,6 @@
 import re
 
+import django
 import pgtrigger
 from django.db import models
 
@@ -73,7 +74,7 @@ class Event(pgtrigger.Trigger):
             f.column: f'{self.row}."{f.column}"'
             for f in self.event_model._meta.fields
             if not isinstance(f, models.AutoField)
-            and not isinstance(f, models.GeneratedField)
+            and not (django.VERSION[0] >= 5 and isinstance(f, models.GeneratedField))
             and f.name in tracked_model_fields
             and f.concrete
         }


### PR DESCRIPTION
Ran into an issue where pghistory was attempting to copy over the value from a GeneratedField into the corresponding GeneratedField on the Event model, which caused an error since you can't set the value on a GeneratedField. GeneratedFields in general should probably just be ignored by the trigger. I'm aware this may not be implemented too well, let me know if there's anything you'd like me to change or redo.

Thank you!