### PR TITLE
Do set_config() only for DML-Satements

### DIFF
--- a/pghistory/runtime.py
+++ b/pghistory/runtime.py
@@ -32,6 +32,15 @@ def _is_concurrent_statement(sql: Union[str, bytes]):
     return sql.startswith("create") and "concurrently" in sql
 
 
+def _is_dml_statement(sql: Union[str, bytes]):
+    """
+    True if the sql statement is a dml statement (insert, update, delete)
+    """
+    sql = sql.strip().lower() if sql else ""
+    sql = sql.decode() if isinstance(sql, bytes) else sql
+    return not sql.startswith("select")
+
+
 def _is_transaction_errored(cursor):
     """
     True if the current transaction is in an errored state
@@ -65,6 +74,7 @@ def _can_inject_variable(cursor, sql):
         not getattr(cursor, "name", None)
         and not _is_concurrent_statement(sql)
         and not _is_transaction_errored(cursor)
+        and _is_dml_statement(sql)
     )
 
 

--- a/pghistory/tests/test_runtime.py
+++ b/pghistory/tests/test_runtime.py
@@ -25,12 +25,10 @@ def test_is_concurrent_statement(statement, expected):
 @pytest.mark.parametrize(
     "sql, params",
     [
-        ("select count(*) from auth_user where id = %s", (1,)),
-        ("select count(*) from auth_user where id = %(id)s", {"id": 5}),
-        ("select count(*) from auth_user", ()),
-        (b"select count(*) from auth_user where id = %s", (1,)),
-        (b"select count(*) from auth_user where id = %(id)s", {"id": 5}),
-        (b"select count(*) from auth_user", ()),
+        ("update auth_user set id= %s where id = %s", (1,1)),
+        ("update auth_user set id= %(id1)s where id = %(id2)s", {"id1": 5, "id2": 1}),
+        (b"update auth_user set id= %s where id = %s", (1,1)),
+        (b"update auth_user set id= %(id1)s where id = %(id2)s", {"id1": 5, "id2": 1}),
     ],
 )
 def test_inject_history_context(settings, mocker, sql, params):


### PR DESCRIPTION
Please review! set_config() should only be issued for dml statements.
test_inject_history_context() does not go through as it is only tested against select statements.