### PR TITLE
Accept Field instance in ProxyField

### DIFF
--- a/pghistory/core.py
+++ b/pghistory/core.py
@@ -492,7 +492,7 @@ def create_event_model(
     return event_model
 
 
-def ProxyField(proxy: str, field: Type[models.Field]):
+def ProxyField(proxy: str, field: models.Field):
     """
     Proxies a JSON field from a model and adds it as a field in the queryset.
 


### PR DESCRIPTION
ProxyField accepts Field instance, not Field class
ref: https://django-pghistory.readthedocs.io/en/3.7.0/aggregating_events/#querying-context-as-structured-fields