### PR TITLE
fix: MiddlewareEvents breaking import without user model app installed

### DIFF
--- a/docs/aggregating_events.md
+++ b/docs/aggregating_events.md
@@ -146,3 +146,4 @@ Unlike individual event models, only the `pgh_context` field can be proxied on t
 ## Using the `MiddlewareEvents` model
 
 If you use [the middleware](context.md#middleware) to attach context on requests, you can make use of `pghistory.models.MiddlewareEvents`, which attaches a `user` and `url` field that correspond to the attributes captured by the middleware.
+When `settings.AUTH_USER_MODEL` is defined, the `user` field will be a foreign key to your `User` model. If it's `None`, for example when the `django.contrib.auth` app is not installed, it will be a plain `TextField`.

--- a/pghistory/models.py
+++ b/pghistory/models.py
@@ -683,21 +683,42 @@ class Events(models.Model):
         return [error for error in errors if error.id != "models.E017"]
 
 
+def _middleware_events_user_field():
+    """
+    Return the MiddlewareEvents user proxy field.
+
+    Uses a ForeignKey when AUTH_USER_MODEL's app is installed, otherwise a
+    TextField so pghistory can import without the user model app present.
+    """
+    auth_user_model = getattr(settings, "AUTH_USER_MODEL", None)
+    if auth_user_model:
+        try:
+            app_label, _ = auth_user_model.split(".", 1)
+        except ValueError:
+            app_label = None
+        if app_label and apps.is_installed(app_label):
+            return core.ProxyField(
+                "pgh_context__user",
+                models.ForeignKey(
+                    settings.AUTH_USER_MODEL,
+                    on_delete=models.DO_NOTHING,
+                    null=True,
+                    help_text="The user associated with the event.",
+                ),
+            )
+    return core.ProxyField(
+        "pgh_context__user",
+        models.TextField(null=True, help_text="The user associated with the event."),
+    )
+
+
 class MiddlewareEvents(Events):
     """
     A proxy model for aggregating events. Includes additional fields that
     are captured by the pghistory middleware
     """
 
-    user = core.ProxyField(
-        "pgh_context__user",
-        models.ForeignKey(
-            settings.AUTH_USER_MODEL,
-            on_delete=models.DO_NOTHING,
-            null=True,
-            help_text="The user associated with the event.",
-        ),
-    )
+    user = _middleware_events_user_field()
     url = core.ProxyField(
         "pgh_context__url",
         models.TextField(null=True, help_text="The url associated with the event."),

--- a/pghistory/tests/test_utils.py
+++ b/pghistory/tests/test_utils.py
@@ -1,0 +1,29 @@
+from django.db import models
+
+from pghistory import models as pgh_models
+
+
+def test_middleware_events_user_field_foreign_key(mocker):
+    mocker.patch("pghistory.models.settings.AUTH_USER_MODEL", "auth.User")
+    mocker.patch("pghistory.models.apps.is_installed", return_value=True)
+    field = pgh_models._middleware_events_user_field()
+    assert isinstance(field, models.ForeignKey)
+
+
+def test_middleware_events_user_field_textfield(mocker):
+    mocker.patch("pghistory.models.settings.AUTH_USER_MODEL", "myapp.User")
+    mocker.patch("pghistory.models.apps.is_installed", return_value=False)
+    field = pgh_models._middleware_events_user_field()
+    assert isinstance(field, models.TextField)
+
+
+def test_middleware_events_user_field_textfield_no_auth_user_model(mocker):
+    mocker.patch("pghistory.models.settings.AUTH_USER_MODEL", None)
+    field = pgh_models._middleware_events_user_field()
+    assert isinstance(field, models.TextField)
+
+
+def test_middleware_events_user_field_textfield_invalid_auth_user_model(mocker):
+    mocker.patch("pghistory.models.settings.AUTH_USER_MODEL", "invalid")
+    field = pgh_models._middleware_events_user_field()
+    assert isinstance(field, models.TextField)


### PR DESCRIPTION
## Summary

`MiddlewareEvents.user` is always declared as a `ForeignKey` to `settings.AUTH_USER_MODEL`, which fails when the user model's app is not in `INSTALLED_APPS`. Django can fail to start even if you never use `MiddlewareEvents`, because the model is defined at import time.

This change checks whether the user model's app is installed and falls back to a `TextField` (same as `url`) when it is not.

## Changes

- Add `_middleware_events_user_field()` in `pghistory/models.py`
- Conditionally define `MiddlewareEvents.user` as `ForeignKey` or `TextField`
- Document the behavior in `docs/aggregating_events.md`
- Add unit tests for both field paths

## Test plan

- [x] `make test` — passed
- [x] `make lint` — ruff and docs passed
- [x] `make full-test-suite` — all tox pytest envs passed

Thanks for maintaining `django-pghistory`! Happy to adjust anything based on feedback.